### PR TITLE
Fix typos in extraction docstrings

### DIFF
--- a/scripts/data_extraction.py
+++ b/scripts/data_extraction.py
@@ -15,9 +15,9 @@ def main():
 def information_extraction_from_pdf(path):
     """
     Data from pdf documents written in a json file compatible to be
-    readed as pandas dataframe
+    read as pandas dataframe
 
-    :param path: User input folder name containing the information to be extrated
+    :param path: User input folder name containing the information to be extracted
     :type path: str
     :raise FileNotFoundError: If path is not correct.
     :rtype: json file
@@ -89,7 +89,7 @@ def pdf_files_path(user_path: str):
     """
     List of documents in folder path
 
-    :param user_path: User input folder name containing the information to be extrated
+    :param user_path: User input folder name containing the information to be extracted
     :type user_path: str
     :raise FileNotFoundError: If the user input is invalid
     :rtype: List containing the pdf documents name

--- a/scripts/extraction_coordinates.py
+++ b/scripts/extraction_coordinates.py
@@ -49,7 +49,7 @@ def visualize_region_of_extraction():
             page.draw_rect(rectangle_black, width=1.5, color=(0, 0, 0))
 
             def text_extraction_validation():
-                """Print the information which has been extrated from the rectangle"""
+                """Print the information which has been extracted from the rectangle"""
                 rectangle_red_text = page.get_textbox(rectangle_red)
                 rectangle_blue_text = page.get_textbox(rectangle_blue)
                 rectangle_yellow_text = page.get_textbox(rectangle_yellow)


### PR DESCRIPTION
## Summary
- fix spelling of `read` and `extracted` in `data_extraction.py`
- update docstring in `extraction_coordinates.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_686d42d09b448332b280a99965e698fa