### PR TITLE
Switch to overwrite mode and verify JSON output

### DIFF
--- a/scripts/data_extraction.py
+++ b/scripts/data_extraction.py
@@ -66,7 +66,7 @@ def information_extraction_from_pdf(path):
                 data_pandas_format.append(data)
 
     # Write data in suitable json format to read as pandas dataframe
-    with open("data.json", "a") as f:
+    with open("data.json", "w") as f:
         json.dump(data_pandas_format, f, ensure_ascii=False, sort_keys=True, indent=2)
 
 

--- a/scripts/tests/test_data_extraction.py
+++ b/scripts/tests/test_data_extraction.py
@@ -1,8 +1,22 @@
+import os
+import sys
+import json
+import types
 import pytest
 import unittest
 
 from unittest.mock import patch
 
+
+# Allow importing modules from the scripts directory
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a minimal stub for the ``fitz`` package used in ``data_extraction``.
+fitz_stub = types.ModuleType("fitz")
+fitz_stub.open = lambda *args, **kwargs: None
+fitz_stub.Rect = object
+fitz_stub.Page = object
+sys.modules.setdefault("fitz", fitz_stub)
 
 from data_extraction import (
     input_test_file_checker,
@@ -31,3 +45,26 @@ class TestExtraction(unittest.TestCase):
 def test_pdf_files_path():
     with pytest.raises(FileNotFoundError):
         pdf_files_path("1.pdf")
+
+
+def test_data_file_overwrite(monkeypatch, tmp_path):
+    """Ensure data.json contains a single JSON array after multiple runs."""
+    # change working directory to a temporary path so data.json is created there
+    monkeypatch.chdir(tmp_path)
+
+    # Ensure no pdf files are processed
+    with patch("data_extraction.pdf_files_path", return_value=[]):
+        # First execution creates the file
+        information_extraction_from_pdf("dummy")
+        with open("data.json", "r") as f:
+            content_first = f.read()
+
+    # Run again and check that file is overwritten, not appended
+    with patch("data_extraction.pdf_files_path", return_value=[]):
+        information_extraction_from_pdf("dummy")
+        with open("data.json", "r") as f:
+            content_second = f.read()
+
+    assert content_first == content_second
+    # Content should be a valid JSON array
+    assert json.loads(content_second) == []


### PR DESCRIPTION
## Summary
- overwrite `data.json` each run instead of appending
- mock `fitz` in tests and update import path handling
- add regression test ensuring `data.json` is overwritten with a valid JSON array

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d42d22c548332af165ae0450302e8