### PR TITLE
Fix test imports for scripts package

### DIFF
--- a/scripts/tests/test_data_extraction.py
+++ b/scripts/tests/test_data_extraction.py
@@ -1,10 +1,24 @@
-import pytest
+import os
+import sys
+import types
 import unittest
-
 from unittest.mock import patch
+import pytest
 
 
-from data_extraction import (
+# Provide a minimal stub for the ``fitz`` module so that ``scripts.data_extraction``
+# can be imported without the optional dependency installed.
+fitz_stub = types.ModuleType("fitz")
+fitz_stub.Page = object
+fitz_stub.Rect = object
+sys.modules.setdefault("fitz", fitz_stub)
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+from scripts.data_extraction import (
     input_test_file_checker,
     pdf_files_path,
     information_extraction_from_pdf,
@@ -18,14 +32,10 @@ def test_information_extraction_from_pdf():
 
 class TestExtraction(unittest.TestCase):
     def test_input_test_file_checker(self):
-        with self.assertRaises(Exception):
-            # arrange
-            path = "anything.pdf"
-            # act
-            with patch("project.sys.exit") as exit_mock:
-                path = input_test_file_checker(path)
-                # assert
-                exit_mock.assert_called_once_with("Too many command-line arguments")
+        """Ensure missing CLI arguments trigger ``SystemExit``."""
+        with patch.object(sys, "argv", ["prog"]):
+            with self.assertRaises(SystemExit):
+                input_test_file_checker()
 
 
 def test_pdf_files_path():


### PR DESCRIPTION
## Summary
- update tests to import from `scripts.data_extraction`
- stub missing `fitz` dependency
- expect `SystemExit` when CLI args are missing
- add path adjustment so tests can locate `scripts`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d42e313708332a2d8a0eb3ffbe2d1